### PR TITLE
Use /usr/bin/env instead of /usr/bin/perl5/perl

### DIFF
--- a/arcstat.pl
+++ b/arcstat.pl
@@ -1,4 +1,4 @@
-#!/usr/perl5/bin/perl -w
+#!/usr/bin/env perl
 #
 # Print out ZFS ARC Statistics exported via kstat(1)
 # For a definition of fields, or usage, use arctstat.pl -v
@@ -43,6 +43,7 @@
 # just iterate over this array and print the values using our pretty printer.
 
 use strict;
+use warnings;
 use POSIX qw(strftime);
 use Sun::Solaris::Kstat;
 use Getopt::Long;


### PR DESCRIPTION
Update to use `/usr/bin/env` instead of a hardcoded `/usr/perl5/bin/perl` so the script will work unedited on Linux, and be more portable.
