### PR TITLE
Add support for compressed L2ARC

### DIFF
--- a/README
+++ b/README
@@ -38,6 +38,7 @@ Field definitions are as follows
     mh% : Metadata hit percentage
 l2miss% : L2ARC access miss percentage
    read : Total Arc accesses per second
+l2asize : Actual (compressed) size of the L2ARC
       c : Arc Target Size
    mfug : MFU Ghost List hits per second
    miss : Arc misses per second

--- a/arcstat.pl
+++ b/arcstat.pl
@@ -88,6 +88,7 @@ my %cols = (# HDR => [Size, Scale, Description]
 	"l2read"	=>[6, 1000, "Total L2ARC accesses per second"],
 	"l2hit%"	=>[6, 100, "L2ARC access hit percentage"],
 	"l2miss%"	=>[7, 100, "L2ARC access miss percentage"],
+	"l2asize"       =>[7, 1024, "Actual (compressed) size of the L2ARC"],
 	"l2size"	=>[6, 1024, "Size of the L2ARC"],
 	"l2bytes"	=>[7, 1024, "bytes read per second from the L2ARC"],
 );


### PR DESCRIPTION
The first commit remove some lines, which are not needed and the second add support for l2asize, which represents the size of the compressed L2ARC.
