### PR TITLE
l2asize should be calculated

### DIFF
--- a/arcstat.pl
+++ b/arcstat.pl
@@ -339,6 +339,7 @@ sub calculate {
 
 		$v{"l2miss%"} = 100 - $v{"l2hit%"} if $v{"l2read"} > 0;
 		$v{"l2size"} = $cur{"l2_size"};
+		$v{"l2asize"} = $cur{"l2_asize"};
 		$v{"l2bytes"} = $d{"l2_read_bytes"}/$int;
 	}
 }


### PR DESCRIPTION
The added parameter for L2ARC compression does not work as expected. It was calculated. This commit actually fixes that. This change was tested on custom build of OpenIndiana.
