### PR TITLE
Print stats since boot for first line

### DIFF
--- a/arcstat.pl
+++ b/arcstat.pl
@@ -352,12 +352,12 @@ sub main {
 	if ($count > 0) { $count_flag = 1; }
 	while (1) {
 		print_header() if ($i == 0);
-		snap_stats();
 		calculate();
 		print_values();
 		last if ($count_flag == 1 && $count-- <= 1);
 		$i = (($i == $hdr_intr) && (not $raw_output)) ? 0 : $i+1;
 		sleep($int);
+		snap_stats();
 	}
 	close($out) if defined $out;
 }


### PR DESCRIPTION
init() already calls snap_stats(), don't call it again the first time through.

Fixes #7 