### PR TITLE
Removal of recycle_miss

### DIFF
--- a/zfs-arcstat.spec
+++ b/zfs-arcstat.spec
@@ -1,0 +1,44 @@
+%global commit 0b4546e89ded86d2f11727d32fb1eb2caaf91ceb
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global repo_name arcstat
+
+Name:           zfs-arcstat
+Version:        0.5
+Release:        1%{?dist}
+Summary:        Perl script to read ZFS ARC kstat values
+License:        GPLv2+
+Group:          Applications/System
+URL:            https://github.com/zfsonlinux/%{repo_name}
+Source0:        https://github.com/zfsonlinux/%{repo_name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:      noarch
+Requires:       perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
+Requires:       perl(Sun::Solaris::Kstat)
+
+%description
+arcstat.pl is a Perl script that uses the Sun::Solaris::Kstat module to read
+ZFS ARC kstat values from the system and report on an interval basis.
+
+%prep
+%setup -qn %{repo_name}-%{commit}
+
+%build
+# Do nothing
+
+%install
+rm -rf $RPM_BUILD_ROOT
+
+mkdir -p %{buildroot}%{_bindir}/
+cp -p arcstat.pl %{buildroot}%{_bindir}/arcstat.pl
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+%doc README
+%attr(0755, root, root) %{_bindir}/arcstat.pl
+
+%changelog
+* Tue Jul 23 2013 Trey Dockendorf <treydock@gmail.com> 0.5-1
+- Initial spec file creation


### PR DESCRIPTION
Running arcstat.pl triggers a division by uninitialized value. This is caused on line 332, where the script attempts to divide `$d{"recycle_miss"}` by `$int`.

`abrams arcstat # arcstat.pl`
`    time  read  miss  miss%  dmis  dm%  pmis  pm%  mmis  mm%  arcsz     c`
`Use of uninitialized value in division (/) at /usr/bin/arcstat.pl line 332.`
`00:30:18    97     0      0     0    0     0    0     0    0   8.0G  8.0G`


recycle_miss does not exist in `/proc/spl/kstat/zfs/arcstats` (at least on my version of spl).


`abrams arcstat # grep -ic recycle /proc/spl/kstat/zfs/arcstats`
`0`


Since this data doesn't appear to be used in the output unless manually specified by the user, it should be safe to remove it entirely.

Just in case this is a weirdness with my version, I'm currently running SPL 0.7.10-1.

I don't have an illumos box sitting around. If this is a specific issue to ZoL feel free to close. 

